### PR TITLE
I think this was the only thing throwing it off?

### DIFF
--- a/background.js
+++ b/background.js
@@ -42,8 +42,6 @@ async function configureNetRequest(tabId, domain) {
 chrome.action.onClicked.addListener(async (tab) => {
   const domain = new URL(tab.url).hostname;
   await configureNetRequest(tab.id, domain);
-  await chrome.tabs.update(tab.id, { url: tab.url });
-  console.log("reloaded");
 
   // Insert the JS file when the user turns the extension on
   await chrome.scripting.executeScript({


### PR DESCRIPTION
This seems to have done it:

![image](https://github.com/siakaramalegos/resp-image-lint-extension/assets/439942/a4114c33-dc22-40e7-b1a6-d09b9c496574)

ABA is on Shopify, and it was erroring out on me as expected before—seems to be working with the changes in this branch!